### PR TITLE
Fixed wrong package name (incorrectly cased 'm')

### DIFF
--- a/menu/desktop/build.gradle
+++ b/menu/desktop/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "java"
 sourceCompatibility = 1.6
 sourceSets.main.java.srcDirs = [ "src/" ]
 
-project.ext.mainClassName = "com.Menu.game.desktop.DesktopLauncher"
+project.ext.mainClassName = "com.menu.game.desktop.DesktopLauncher"
 project.ext.assetsDir = new File("../core/assets");
 
 task run(dependsOn: classes, type: JavaExec) {


### PR DESCRIPTION
IDK why this case mismatch wasn't a problem before (maybe its because linux has case sensitive filenames?) But I had to fix the main classname to get it to launch. It works on my laptop now.

Can someone on windows confirm that this change doesn't break builds for other OS's? I don't think that will be the case, but I want to be sure I don't break anything.
